### PR TITLE
Add KINT & KBTC for Karura.

### DIFF
--- a/chainParsers/acala.js
+++ b/chainParsers/acala.js
@@ -81,7 +81,19 @@ module.exports = class AcalaParser extends ChainParser {
                 "Token": "KSM"
             },
             xcmInteriorKey: '[{"network":"kusama"},"here"]'
-        }
+        },
+        {
+            asset: {
+                "Token": "KINT"
+            },
+            xcmInteriorKey: '[{"network":"kusama"},{"parachain":2092},{"generalKey":"0x000C"}]'
+        },
+        {
+            asset: {
+                "Token": "KBTC"
+            },
+            xcmInteriorKey: '[{"network":"kusama"},{"parachain":2092},{"generalKey":"0x000B"}]'
+        },
         ]
     }
 


### PR DESCRIPTION
$KINT and $KBTC xcm locations in Karura are hard coded and thus need manual registration.

https://github.com/AcalaNetwork/Acala/blob/b5fdeddcb976365f7133bbd5de4aaafd98976877/runtime/karura/src/xcm_config.rs#L364-L373