### PR TITLE
SKIP Phala AssetRegistry

### DIFF
--- a/publicEndpoints/polkadot_publicEndpoints.json
+++ b/publicEndpoints/polkadot_publicEndpoints.json
@@ -205,8 +205,8 @@
     "id": "phala",
     "paraID": 2035,
     "WSEndpoints": [
-      "wss://api.phala.network/ws",
-      "wss://phala.api.onfinality.io/public-ws"
+      "wss://skip.api.phala.network/ws",
+      "wss://skip.phala.api.onfinality.io/public-ws"
     ],
     "relaychain": "polkadot"
   },


### PR DESCRIPTION
Skip phala asset registry parsing due to: https://github.com/colorfulnotion/xcm-global-registry/issues/34