### PR TITLE
Add pendulum parser

### DIFF
--- a/chainParsers/pendulum.js
+++ b/chainParsers/pendulum.js
@@ -48,7 +48,20 @@ module.exports = class PendulumParser extends ChainParser {
     }
     */
     augment = {}
-    manualRegistry = {}
+    manualRegistry = {
+        "polkadot-2094": [{
+            asset: {
+                "Token": "PEN"
+            },
+            xcmInteriorKey: '[{"network":"polkadot"},{"parachain":2094},{"palletInstance":10}]'
+        }],
+        'kusama-2124': [{
+            asset: {
+                "Token": "AMPE"
+            },
+            xcmInteriorKey: '[{"network":"kusama"},{"parachain":2124},{"palletInstance":10}]'
+        }]
+    }
 
     isXcRegistryAvailable = true
 
@@ -88,6 +101,7 @@ module.exports = class PendulumParser extends ChainParser {
             // step 2: load up results
             for (const assetChainkey of Object.keys(assetList)) {
                 let assetInfo = assetList[assetChainkey]
+                // Some parsers pad the currency ID here. Should we do too?
                 this.manager.setChainAsset(chainkey, assetChainkey, assetInfo)
             }
         }

--- a/chainParsers/pendulum.js
+++ b/chainParsers/pendulum.js
@@ -114,11 +114,11 @@ module.exports = class PendulumParser extends ChainParser {
         let relayChain = pieces[0]
         let paraIDSource = pieces[1]
         //step 0: use fetchQuery to retrieve xc registry at the location [assetManager:assetIdType]
-        var a = await super.fetchQuery(chainkey, this.xcGarPallet, this.xcGarStorage, 'xcGAR')
+        let a = await super.fetchQuery(chainkey, this.xcGarPallet, this.xcGarStorage, 'xcGAR')
         if (!a) return
         if (a) {
             // step 1: use common XcmAssetIdType parser func available at generic chainparser.
-            let [xcAssetList, assetIDList, updatedAssetList, unknownAsset] = await this.processXcmAssetsRegistryAssetMetadata(chainkey, a, "XCM")
+            let [xcAssetList, assetIDList, updatedAssetList, unknownAsset] = await this.processXcmAssetsRegistryAssetMetadata(chainkey, a, "Token")
             console.log(`custom xcAssetList=[${Object.keys(xcAssetList)}], updatedAssetList=[${Object.keys(updatedAssetList)}], unknownAsset=[${Object.keys(unknownAsset)}], assetIDList=[${Object.keys(assetIDList)}]`, xcAssetList)
             // step 2: load up results
             for (const xcmInteriorKey of Object.keys(xcAssetList)) {

--- a/chainParsers/pendulum.js
+++ b/chainParsers/pendulum.js
@@ -1,0 +1,161 @@
+const xcmgarTool = require("../xcmgarTool");
+const ChainParser = require("./common_chainparser");
+
+/*
+Support chains
+polkadot-2094|pendulum
+kusama-2124|amplitude
+*/
+
+module.exports = class PendulumParser extends ChainParser {
+
+    parserName = 'Pendulum';
+
+    //change [garPallet:garPallet] to the location where the asset registry is located.  ex: [assets:metadata]
+    garPallet = 'assetRegistry';
+    garStorage = 'metadata';
+
+    //change [xcGarPallet:xcGarStorage] to the location where the xc registry is located.  ex: [assetManager:assetIdType]
+    xcGarPallet = 'assetRegistry'
+    xcGarStorage = 'metadata'
+
+    /*
+    Not every parachain has published its xc Asset registry. But we
+    can still augment xcAsset registry by inferring.
+
+    To augment the xcAsset by parsing, please provide an array of xcm extrinsicIDs
+    containing the xcAsset asset you try to cover:
+
+    augment = {
+        'relaychain-paraID': [{
+            paraID: 'paraID',
+            extrinsicIDs: ['extrinsicID']
+        }]
+    }
+    */
+
+    /*
+    Parachain usually does not publish native asset in its own xc registry.
+    Allow team to polish xcRegistry using the following format:
+
+    manualRegistry = {
+        "relaychain-paraID": [{
+            asset: {
+                "Token": "currencyID"
+            },
+            xcmV1Standardized: [{"network":"relaychain"},{"parachain":paraID},{palletInstance/generalKey/generalIndex...}],
+        }]
+    }
+    */
+    augment = {}
+    manualRegistry = {}
+
+    isXcRegistryAvailable = true
+
+    //step 1: parse gar pallet, storage for parachain's asset registry
+    async fetchGar(chainkey) {
+        // implement your gar parsing function here.
+        await this.processPendulumGar(chainkey)
+    }
+
+    //step 2: parse xcGar pallet, storage for parachain's xc asset registry
+    async fetchXcGar(chainkey) {
+        if (!this.isXcRegistryAvailable) {
+            // skip if xcGar parser is unavailable
+            console.log(`[${chainkey}] ${this.parserName} xcGar NOT IMPLEMENTED - SKIP`)
+            return
+        }
+        // implement your xcGar parsing function here.
+        await this.processPendulumXcGar(chainkey)
+    }
+
+    //step 3: Optional augmentation by providing (a) a list xcm extrinsicIDs or (b) known xcmInteriorKeys-assets mapping
+    async fetchAugments(chainkey) {
+        //[Optional A] implement your augment parsing function here.
+        await this.processPendulumAugment(chainkey)
+        //[Optional B ] implement your manual registry here.
+        await this.processPendulumManualRegistry(chainkey)
+    }
+
+    // Implement Pendulum gar parsing function here
+    async processPendulumGar(chainkey) {
+        console.log(`[${chainkey}] ${this.parserName} custom GAR parser`)
+        //step 0: use fetchQuery to retrieve gar registry at the location [assets:garStorage]
+        let a = await super.fetchQuery(chainkey, this.garPallet, this.garStorage, 'GAR')
+        if (a) {
+            // step 1: use common Asset pallet parser func available at generic chainparser.
+            let assetList = this.processGarAssetPallet(chainkey, a)
+            // step 2: load up results
+            for (const assetChainkey of Object.keys(assetList)) {
+                let assetInfo = assetList[assetChainkey]
+                this.manager.setChainAsset(chainkey, assetChainkey, assetInfo)
+            }
+        }
+    }
+
+    // Implement Pendulum xcgar parsing function here
+    async processPendulumXcGar(chainkey) {
+        console.log(`[${chainkey}] ${this.parserName} custom xcGAR parser`)
+        let pieces = chainkey.split('-')
+        let relayChain = pieces[0]
+        let paraIDSource = pieces[1]
+        //step 0: use fetchQuery to retrieve xc registry at the location [assetManager:assetIdType]
+        var a = await super.fetchQuery(chainkey, this.xcGarPallet, this.xcGarStorage, 'xcGAR')
+        if (!a) return
+        if (a) {
+            // step 1: use common XcmAssetIdType parser func available at generic chainparser.
+            let [xcAssetList, assetIDList, updatedAssetList, unknownAsset] = await this.processXcmAssetsRegistryAssetMetadata(chainkey, a, "XCM")
+            console.log(`custom xcAssetList=[${Object.keys(xcAssetList)}], updatedAssetList=[${Object.keys(updatedAssetList)}], unknownAsset=[${Object.keys(unknownAsset)}], assetIDList=[${Object.keys(assetIDList)}]`, xcAssetList)
+            // step 2: load up results
+            for (const xcmInteriorKey of Object.keys(xcAssetList)) {
+                let xcmAssetInfo = xcAssetList[xcmInteriorKey]
+                let assetID = assetIDList[xcmInteriorKey]
+                this.manager.setXcmAsset(xcmInteriorKey, xcmAssetInfo, chainkey)
+                // update global xcRegistry to include assetID used by this parachain
+                this.manager.addXcmAssetLocalCurrencyID(xcmInteriorKey, paraIDSource, assetID, chainkey)
+            }
+            for (const assetChainkey of Object.keys(updatedAssetList)) {
+                let assetInfo = updatedAssetList[assetChainkey]
+                this.manager.setChainAsset(chainkey, assetChainkey, assetInfo, true)
+            }
+        }
+    }
+
+    // Implement Pendulum manual registry function here
+    async processPendulumManualRegistry(chainkey) {
+        console.log(`[${chainkey}] ${this.parserName} manual`)
+        let pieces = chainkey.split('-')
+        let relayChain = pieces[0]
+        let paraIDSource = pieces[1]
+        let manualRecs = this.manualRegistry[chainkey]
+        this.processManualRegistry(chainkey, manualRecs)
+    }
+
+    // Implement Pendulum Augment function here
+    async processPendulumAugment(chainkey) {
+        console.log(`[${chainkey}] ${this.parserName} custom augmentation`)
+        let pieces = chainkey.split('-')
+        let relayChain = pieces[0]
+        let paraIDSource = pieces[1]
+        let recs = this.augment[chainkey]
+        // step 0: fetch specified extrinsics
+        let augmentedExtrinsics = await this.fetchAugmentedExtrinsics(chainkey, recs)
+        for (const augmentedExtrinsic of augmentedExtrinsics) {
+            console.log(`augmentedExtrinsic`, augmentedExtrinsic)
+            // step 1: use common xTokens parser func available at generic chainparser.
+            let augmentedMap = this.processOutgoingXTokens(chainkey, augmentedExtrinsic)
+            // step 2: load up results
+            for (const xcmInteriorKey of Object.keys(augmentedMap)) {
+                let augmentedInfo = augmentedMap[xcmInteriorKey]
+                let assetID = augmentedInfo.assetID
+                let assetChainkey = augmentedInfo.assetChainkey
+                this.manager.addXcmAssetLocalCurrencyID(xcmInteriorKey, paraIDSource, assetID, chainkey)
+                let cachedAssetInfo = this.manager.getChainAsset(assetChainkey)
+                if (cachedAssetInfo) {
+                    cachedAssetInfo.xcmInteriorKey = xcmInteriorKey
+                    this.manager.setChainAsset(chainkey, assetChainkey, cachedAssetInfo)
+                }
+            }
+        }
+    }
+}

--- a/xcmgarManager.js
+++ b/xcmgarManager.js
@@ -23,6 +23,7 @@ const RobonomicsParser = require("./chainParsers/robonomics")
 const CentrifugeParser = require("./chainParsers/centrifuge")
 const CloverParser = require("./chainParsers/clover")
 const OriginTrailParser = require("./chainParsers/origintrail")
+const PendulumParser = require("./chainParsers/pendulum")
 
 const {
     ApiPromise,
@@ -464,6 +465,8 @@ module.exports = class XCMGlobalAssetRegistryManager {
             chainParser = new CloverParser(api, manager)
         } else if (this.isMatched(chainkey, ['polkadot-2043|origintrail'])) {
             chainParser = new OriginTrailParser(api, manager)
+        } else if (this.isMatched(chainkey, ['polkadot-2094|pendulum', 'kusama-2124|amplitude'])) {
+            chainParser = new PendulumParser(api, manager)
         } else {
             chainParser = new CommonChainParser(api, manager, false) // set isCustomParser to false
         }


### PR DESCRIPTION
This PR adds a parser for the asset registries of the Pendulum and Amplitude networks.

This is a follow-up to https://github.com/colorfulnotion/xcm-global-registry/pull/40. By now we have the metadata available on Amplitude so that this parsing can actually be tested. 